### PR TITLE
Enable stateless mode for StreamableHTTPHandler

### DIFF
--- a/main.go
+++ b/main.go
@@ -174,10 +174,10 @@ func main() {
 	})
 
 	if *httpAddr != "" {
-		handler := mcp.NewSSEHandler(func(*http.Request) *mcp.Server {
+		handler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server {
 			return srv
-		}, nil)
-		log.Printf("Starting SSE/HTTP server at %s", *httpAddr)
+		}, &mcp.StreamableHTTPOptions{Stateless: true})
+		log.Printf("Starting Streamable HTTP server at %s", *httpAddr)
 		if err := http.ListenAndServe(*httpAddr, handler); err != nil {
 			log.Fatalf("HTTP server failed: %v", err)
 		}


### PR DESCRIPTION
Update `NewStreamableHTTPHandler` to pass `&mcp.StreamableHTTPOptions{Stateless: true}` to enable the stateless 2026-07-28 protocol over HTTP transport.